### PR TITLE
fixed load yaml file method

### DIFF
--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -114,7 +114,7 @@ Server =
 
   start: ->
     promise = new Hope.Promise()
-    @instance.listen process.env.PORT or process.env.VCAP_APP_PORT or environment.server.port, =>
+    @instance.listen process.env.VCAP_APP_PORT or environment.server.port, =>
       callback.call callback, @instance if callback?
       promise.done null, true
     promise


### PR DESCRIPTION
Al cargar directamente con require da un warning en consola

> > Direct yaml files load via require() is deprecated! Use safeLoad() instead.
